### PR TITLE
Adding rolling ball background subtraction and interactive processing QOL updates

### DIFF
--- a/examples/interactive_filtering/interactive_scikit_processing_single_image.py
+++ b/examples/interactive_filtering/interactive_scikit_processing_single_image.py
@@ -22,7 +22,7 @@ import imppy3d.cv_processing_wrappers as cwrap
 import imppy3d.import_export as imex
 import imppy3d.plt_wrappers as pwrap
 import imppy3d.ski_driver_functions as sdrv
-
+import imppy3d.ski_interactive_processing as sint
 
 # Set constants related to plotting (for MatPlotLib)
 SMALL_SIZE = 10
@@ -91,19 +91,14 @@ print(f"\nInitiating interactive sharpening filter...")
 img2 = sdrv.interact_driver_sharpen(img2, "unsharp_mask")
 
 
-# -------- GLOBAL THRESHOLDING --------
-print(f"\nInitiating interactive global thresholding...")
-img2 = sdrv.interact_driver_thresholding(img2, "global_threshold")
+# -------- SEGMENTATION TYPE SELECTOR --------
+print(f"\\nChoose a segmentation type...")
+seg_type = sint.interact_segmentation_type()
 
 
-# -------- ADAPTIVE THRESHOLDING --------
-#print(f"\nInitiating interactive adaptive thresholding...")
-#img2 = sdrv.interact_driver_thresholding(img2, "adaptive_threshold")
-
-
-# -------- HYSTERESIS THRESHOLDING --------
-#print(f"\nInitiating interactive hysteresis thresholding...")
-#img2 = sdrv.interact_driver_thresholding(img2, "hysteresis_threshold_text")
+# -------- THRESHOLDING (dispatched by selector) --------
+print(f"\\nInitiating interactive {seg_type} thresholding...")
+img2 = sdrv.interact_driver_thresholding(img2, seg_type)
 
 
 # -------- MORPHOLOGICAL OPERATIONS --------

--- a/src/imppy3d/ski_driver_functions.py
+++ b/src/imppy3d/ski_driver_functions.py
@@ -5,6 +5,7 @@ from skimage import segmentation as seg
 from skimage import filters as filt
 from skimage import morphology as morph
 import skimage.feature as sfeature
+from skimage import util
 from skimage.util import img_as_bool, img_as_ubyte, img_as_float
 
 # Import local packages
@@ -383,6 +384,145 @@ def apply_driver_edge_detect(img_in, fltr_params_in, quiet_in=False):
                 f"    High Threshold: {high_thresh_out}")
 
     return img_fltr, mask_out
+
+
+def interact_driver_rolling_ball(img_in, radius_init=35):
+    """
+    Interactively implements rolling ball background subtraction on a
+    single 2D image slice. The output parameters of this function are
+    suitable for input for apply_driver_rolling_ball() below.
+
+    NOTE: This function operates on a single 2D image slice. For 3D
+    image stacks, call this on one representative slice to determine
+    the radius, then apply the result to each slice using
+    apply_driver_rolling_ball() in a loop. See the docstring of
+    interact_rolling_ball() for an example.
+
+    ---- INPUT ARGUMENTS ----
+    [img_in]: Numpy array for a single 2D grayscale image. It is
+        assumed that the image is already grayscale and of type uint8.
+        The array should thus be 2D (num_rows, num_cols), where each
+        value represents the intensity for each corresponding pixel.
+        Do not pass a 3D image stack; use a slice-by-slice loop
+        with apply_driver_rolling_ball() instead.
+
+    [radius_init]: Initial rolling ball radius in pixels. Default is 35.
+
+    ---- RETURNED ----
+    [img_out]: Returns the final 2D image after closing the interactive
+        session. img_out is in the same format as img_in.
+
+    ---- SIDE EFFECTS ----
+    Function input arguments are not altered. Nothing is written to the
+    hard drive. This function is a read-only function. It does pop-up
+    a new window that visualizes the provided image. Strings are printed
+    to standard output.
+    """
+
+    [img_fltr, fltr_params] = ifun.interact_rolling_ball(img_in,
+        radius_init=radius_init)
+
+    # Using this function just to write to standard output
+    apply_driver_rolling_ball(img_in, fltr_params)
+
+    return img_fltr
+
+
+def apply_driver_rolling_ball(img_in, fltr_params_in, quiet_in=False):
+    """
+    Applies rolling ball background subtraction to a single 2D image
+    slice. This is the non-interactive version of
+    interact_driver_rolling_ball().
+
+    The rolling ball algorithm estimates the background intensity by
+    rolling a ball of a given radius under the intensity surface.
+    Larger radii produce smoother background estimates, while smaller
+    radii follow local intensity variations more closely. This function
+    assumes that the features of interest are darker than the
+    background. Internally, the image is inverted before applying the
+    rolling ball, the estimated background is subtracted, and the
+    result is re-inverted. The function is rather expensive,
+    especially for larger values of radius.
+
+    NOTE: This function operates on a single 2D image slice. For 3D
+    image stacks, call this function in a slice-by-slice loop:
+
+        fltr_params = ["rolling_ball", 35]
+        for i in range(imgs_3d.shape[0]):
+            imgs_3d[i] = apply_driver_rolling_ball(
+                imgs_3d[i], fltr_params, quiet_in=True)
+
+    In some applications, one might consider varying the radius
+    based on i-location, if the intensity differences change as a
+    function of height. One could also re-slice the image if the
+    background variation one wishes to remove varies along height
+    instead of in width or depth. E.g., for serial sectioning one
+    might do this to overcome detector drift over sequences of images,
+    or one might apply it to both x-stack and z-stack direction if
+    background tone changes both side to side and vertically.
+
+    ---- INPUT ARGUMENTS ----
+    [img_in]: Numpy array for a single 2D grayscale image. It is
+        assumed that the image is already grayscale and of type uint8.
+        The array should thus be 2D (num_rows, num_cols), where each
+        value represents the intensity for each corresponding pixel.
+        Do not pass a 3D image stack; use a slice-by-slice loop
+        instead (see example above).
+
+    fltr_params_in: A list of parameters needed to perform the
+        background subtraction. The first parameter is a string, which
+        should be "rolling_ball". Example parameter list:
+
+            ["rolling_ball", radius]
+
+                radius: The rolling ball radius in pixels. Should be a
+                    positive integer. A larger radius results in a
+                    smoother background estimate.
+
+    quiet_in: A boolean that determines if this function should print
+        any statements to standard output. If False (default), outputs
+        are written. Conversely, if True, outputs are suppressed. This
+        is particularly useful in the event of batch processing
+        (e.g., looping over slices in a 3D stack).
+
+    ---- RETURNED ----
+    [img_out]: Returns the resultant 2D Numpy image after performing
+        the background subtraction. img_out is in the same format as
+        img_in.
+
+    ---- SIDE EFFECTS ----
+    Function input arguments are not altered. Nothing is written to the
+    hard drive. This function is a read-only function. Strings are
+    printed to standard output.
+    """
+
+    # ---- Local Copies ----
+    img = img_in.copy()
+    fltr_params = fltr_params_in
+    quiet = quiet_in
+
+    fltr_name = (fltr_params[0]).lower()
+
+    if fltr_name == "rolling_ball":
+        radius_in = int(fltr_params[1])
+
+        img_inv = util.invert(img)
+        bg = rest.rolling_ball(img_inv, radius=radius_in, nansafe=False)
+        bg = img_as_ubyte(bg)
+        img_fltr = util.invert(img_inv - bg)
+        img_fltr = img_as_ubyte(img_fltr)
+
+        if not quiet:
+            print(f"\nSuccessfully applied rolling ball background "
+                  f"subtraction:\n"
+                  f"    Rolling ball radius (pixels): {radius_in}")
+
+    else:
+        print(f"\nERROR: {fltr_name} is not a supported background "
+              f"subtraction method.")
+        img_fltr = img
+
+    return img_fltr
 
 
 def interact_driver_thresholding(img_in, fltr_name_in):

--- a/src/imppy3d/ski_driver_functions.py
+++ b/src/imppy3d/ski_driver_functions.py
@@ -699,7 +699,7 @@ def apply_driver_thresholding(img_in, fltr_params_in, quiet_in=False):
                 f"    Offset (+/-): {thresh_offset}")
 
     else:
-        print(f"\nERROR: {fltr_name} is not a supported sharpening filter.")
+        print(f"\nERROR: {fltr_name} is not a supported thresholding filter.")
         img_fltr = img
 
     return img_fltr

--- a/src/imppy3d/ski_interactive_processing.py
+++ b/src/imppy3d/ski_interactive_processing.py
@@ -909,9 +909,14 @@ def interact_hysteresis_threshold(img_in):
     img_obj = ax.imshow(img_out, cmap='gray', vmin=0, vmax=255)
     ax.set_xlabel("X Pixel Number")
     ax.set_ylabel("Y Pixel Number")
-
+    
     plt.subplots_adjust(bottom=0.26)
-
+    
+    # Status text for busy indicator
+    status_text = fig.text(0.5, 0.005, 'Ready', ha='center',
+                           fontsize=10, color='green',
+                           fontweight='bold')
+    
     # Create new axes objects for each button/slider/text widget
     # 4-tuple of floats rect = [left, bottom, width, height]. A new axes 
     # is added with dimensions rect in normalized (0, 1) units using 
@@ -930,21 +935,31 @@ def interact_hysteresis_threshold(img_in):
         nonlocal high_val_out
         nonlocal img_out
 
+        # Show busy indicator before computation
+        status_text.set_text('Computing...')
+        status_text.set_color('red')
+        fig.canvas.draw_idle()
+        fig.canvas.flush_events()
+
         low_val_out = np.round(low_val_slider.val)
         low_val_out = low_val_out.astype(np.uint16)
 
         high_val_out = np.round(high_val_slider.val)
         high_val_out = high_val_out.astype(np.uint16)
 
-        img_temp = filt.apply_hysteresis_threshold(img_0, low_val_out, 
+        img_temp = filt.apply_hysteresis_threshold(img_0, low_val_out,
         high_val_out)
         img_out = img_as_ubyte(img_temp)
 
         # Update the image
         img_obj.set(data=img_out)
+
+        # Restore ready indicator
+        status_text.set_text('Ready')
+        status_text.set_color('green')
         fig.canvas.draw()
 
-    # Call the update function when the 'update' button is clicked
+    # Call the update function when the sliders are changed
     low_val_slider.on_changed(hysteresis_threshod_update)
     high_val_slider.on_changed(hysteresis_threshod_update)
 
@@ -973,11 +988,11 @@ def interact_hysteresis_threshold2(img_in):
     low_val_0 = thresh_arr[0]
     high_val_0 = thresh_arr[1]
 
-    img_temp = filt.apply_hysteresis_threshold(img_0, low_val_0, 
+    img_temp = filt.apply_hysteresis_threshold(img_0, low_val_0,
         high_val_0)
     img_temp = img_as_ubyte(img_temp)
 
-    # Global variables (within this function) that will be returned. 
+    # Global variables (within this function) that will be returned.
     # Initialize these to the starting values for now.
     low_val_out = low_val_0
     high_val_out = high_val_0
@@ -998,16 +1013,21 @@ def interact_hysteresis_threshold2(img_in):
 
     plt.subplots_adjust(bottom=0.26)
 
+    # Status text for busy indicator
+    status_text = fig.text(0.5, 0.005, 'Ready', ha='center',
+                           fontsize=10, color='green',
+                           fontweight='bold')
+
     # Create new axes objects for each button/slider/text widget
-    # 4-tuple of floats rect = [left, bottom, width, height]. A new axes 
-    # is added with dimensions rect in normalized (0, 1) units using 
+    # 4-tuple of floats rect = [left, bottom, width, height]. A new axes
+    # is added with dimensions rect in normalized (0, 1) units using
     # add_axes on the current figure.
     low_val_ax = fig.add_axes([0.22, 0.11, 0.15, 0.06])
-    low_val_text_box = TextBox(ax=low_val_ax, label='Lower Threshold  ', 
+    low_val_text_box = TextBox(ax=low_val_ax, label='Lower Threshold  ',
         initial=str(low_val_0), textalignment='center')
 
     high_val_ax = fig.add_axes([0.71, 0.11, 0.15, 0.06])
-    high_val_text_box = TextBox(ax=high_val_ax, label='Higher Threshold  ', 
+    high_val_text_box = TextBox(ax=high_val_ax, label='Higher Threshold  ',
         initial=str(high_val_0), textalignment='center')
 
     update_ax = plt.axes([0.25, 0.03, 0.5, 0.05])
@@ -1019,15 +1039,27 @@ def interact_hysteresis_threshold2(img_in):
         nonlocal high_val_out
         nonlocal img_out
 
+        # Show busy indicator before computation
+        status_text.set_text('Computing...')
+        status_text.set_color('red')
+        update_button.label.set_text('Computing...')
+        fig.canvas.draw_idle()
+        fig.canvas.flush_events()
+
         low_val_out = int(low_val_text_box.text)
         high_val_out = int(high_val_text_box.text)
 
-        img_temp = filt.apply_hysteresis_threshold(img_0, low_val_out, 
+        img_temp = filt.apply_hysteresis_threshold(img_0, low_val_out,
         high_val_out)
         img_out = img_as_ubyte(img_temp)
 
         # Update the image
         img_obj.set(data=img_out)
+
+        # Restore ready indicator
+        status_text.set_text('Ready')
+        status_text.set_color('green')
+        update_button.label.set_text('Update')
         fig.canvas.draw()
 
     # Call the update function when the 'update' button is clicked
@@ -1424,6 +1456,13 @@ def interact_nl_means_denoise(img_in):
 
     plt.subplots_adjust(bottom=0.26)
 
+    plt.subplots_adjust(bottom=0.26)
+
+    # Status text for busy indicator
+    status_text = fig.text(0.5, 0.005, 'Ready', ha='center',
+                           fontsize=10, color='green',
+                           fontweight='bold')
+
     # Create new axes objects for each button/slider/text widget
     # 4-tuple of floats rect = [left, bottom, width, height]. A new axes 
     # is added with dimensions rect in normalized (0, 1) units using 
@@ -1445,29 +1484,37 @@ def interact_nl_means_denoise(img_in):
 
     # Update the figure anytime the 'update' button is clicked
     def nl_means_denoise_update(event):
-        # Use the new Python keyword 'nonlocal' to gain access and 
-        # update these variables from within this scope.
         nonlocal h_out
         nonlocal patch_size_out
         nonlocal patch_dist_out
         nonlocal img_out
-
-        # The GUI widgets are defined in a higher-level scope, so
-        # they can be accessed directly within this interior function 
+        
+        # Show busy indicator before computation
+        status_text.set_text('Computing...')
+        status_text.set_color('red')
+        update_button.label.set_text('Computing...')
+        fig.canvas.draw_idle()
+        fig.canvas.flush_events()
+     
         h_out = float(h_text_box.text)
         patch_size_out = int(p_size_text_box.text)
         patch_dist_out = int(p_dist_text_box.text)
 
-        img_out = rest.denoise_nl_means(img_0, h=h_out, 
-        sigma=sig_noise, fast_mode=True, patch_size=patch_size_out, 
+        img_out = rest.denoise_nl_means(img_0, h=h_out,
+        sigma=sig_noise, fast_mode=True, patch_size=patch_size_out,
         patch_distance=patch_dist_out, channel_axis=None)
-
+        
         img_out = img_as_ubyte(img_out)
-
+        
         # Update the image
         img_obj.set(data=img_out)
-        fig.canvas.draw()
 
+        # Restore ready indicator
+        status_text.set_text('Ready')
+        status_text.set_color('green')
+        update_button.label.set_text('Update')
+        fig.canvas.draw()
+        
     # Call the update function when the 'update' button is clicked
     update_button.on_clicked(nl_means_denoise_update)
 

--- a/src/imppy3d/ski_interactive_processing.py
+++ b/src/imppy3d/ski_interactive_processing.py
@@ -8,6 +8,7 @@ from skimage import segmentation as seg
 from skimage import filters as filt
 from skimage import morphology as morph
 import skimage.feature as sfeature
+from skimage import util
 from skimage.util import img_as_bool, img_as_ubyte, img_as_float
 
 
@@ -356,7 +357,6 @@ def interact_canny_edge(img_in):
     return [img_out, mask_out, fltr_params]
 
 
-
 def interact_unsharp_mask(img_in):
     """
     Sharpens an image using unsharp masking, implemented in SciKit-Image
@@ -471,6 +471,177 @@ def interact_unsharp_mask(img_in):
 
     return [img_out, fltr_params]
 
+
+def interact_rolling_ball(img_in, radius_init=35):
+    """
+    Interactively tune rolling ball background subtraction on a single
+    2D grayscale image. The rolling ball algorithm estimates the
+    background intensity by rolling a ball of a given radius under
+    the intensity surface. Larger radii produce smoother background
+    estimates, while smaller radii follow local intensity variations
+    more closely. Especially for larger radii, this filter can be
+    rather computationally costly.
+
+    The algorithm is implemented via
+    skimage.restoration.rolling_ball(). This function assumes that the
+    features of interest are darker than the background. Internally,
+    the image is inverted before applying the rolling ball (so that the
+    algorithm sees light features on a dark background), the estimated
+    background is subtracted, and the result is re-inverted. A
+    three-panel display shows the original image, the background-
+    corrected result, and the estimated background. This is an
+    interactive function that uses Matplotlib widgets (TextBox, Button).
+
+    NOTE: This function operates on a single 2D image slice. For 3D
+    image stacks, apply this function to one representative slice to
+    determine the radius parameter, then use
+    apply_driver_rolling_ball() in a slice-by-slice loop over the
+    full stack. For example:
+
+        # Tune interactively on one slice
+        [_, fltr_params] = interact_rolling_ball(imgs_3d[0])
+
+        # Apply to every slice in the 3D stack
+        for i in range(imgs_3d.shape[0]):
+            imgs_3d[i] = apply_driver_rolling_ball(
+                imgs_3d[i], fltr_params, quiet_in=True)
+
+    Depending on application, you could also set several different
+    rolling-ball radii depending on i-location in the stack, for
+    instance.
+
+     ---- INPUT ARGUMENTS ----
+    [img_in]: Numpy array for a single 2D grayscale image. It is
+        assumed that the image is already grayscale and of type uint8.
+        The array should thus be 2D (num_rows, num_cols), where each
+        value represents the intensity for each corresponding pixel.
+        Do not pass a 3D image stack; use a slice-by-slice loop
+        with apply_driver_rolling_ball() instead.
+
+    [radius_init]: Initial rolling ball radius in pixels. A larger
+        radius results in a smoother background estimate, but take
+        longer to compute. Default is 35.
+
+     ---- RETURNED ----
+    [[img_out], [fltr_params]]: Returns a list containing the resultant
+        image and the parameters used for the filter. img_out is a
+        background-corrected 2D image in the same format as img_in.
+        fltr_params is also a list, which contains the final parameters
+        used during the interactive session. The first item is the
+        string name of the filter that was used, in this case
+        "rolling_ball". For this function, the [fltr_params] list
+        contains:
+
+            ["rolling_ball", radius_out]
+
+                radius_out: The rolling ball radius in pixels. Should
+                    be a positive integer.
+
+     ---- SIDE EFFECTS ----
+    Function input arguments are not altered. Nothing is written to the
+    hard drive. This function is a read-only function. It does pop-up
+    a new window that visualizes the provided image. Strings are printed
+    to standard output.
+    """
+
+    img_0 = img_in.copy()
+
+    # Initial processing
+    radius_out = int(radius_init)
+
+    img_inv = util.invert(img_0)
+    bg = rest.rolling_ball(img_inv, radius=radius_out, nansafe=False)
+    bg = img_as_ubyte(bg)
+    img_out = util.invert(img_inv - bg)
+    img_out = img_as_ubyte(img_out)
+
+    # Create figure with 3 panels: original, corrected, background
+    fig_size = (16, 6)
+
+    fig, (ax_orig, ax_corr, ax_bg) = plt.subplots(1, 3)
+    fig.set_size_inches(fig_size[0], fig_size[1])
+
+    ax_orig.imshow(img_0, cmap='gray', vmin=0, vmax=255)
+    ax_orig.set_title("Original")
+    ax_orig.set_xlabel("X Pixel Number")
+    ax_orig.set_ylabel("Y Pixel Number")
+
+    img_corr_obj = ax_corr.imshow(img_out, cmap='gray', vmin=0, vmax=255)
+    ax_corr.set_title(f"Background-corrected (r={radius_out})")
+    ax_corr.set_xlabel("X Pixel Number")
+    ax_corr.set_ylabel("Y Pixel Number")
+
+    img_bg_obj = ax_bg.imshow(bg, cmap='gray', vmin=0, vmax=255)
+    ax_bg.set_title("Estimated background")
+    ax_bg.set_xlabel("X Pixel Number")
+    ax_bg.set_ylabel("Y Pixel Number")
+
+    plt.subplots_adjust(bottom=0.20)
+
+    # Status text for busy indicator
+    status_text = fig.text(0.5, 0.01, 'Ready', ha='center',
+                           fontsize=10, color='green',
+                           fontweight='bold')
+
+    # Create new axes objects for each widget.
+    # 4-tuple of floats rect = [left, bottom, width, height]. A new axes
+    # is added with dimensions rect in normalized (0, 1) units using
+    # add_axes on the current figure.
+    radius_ax = fig.add_axes([0.35, 0.06, 0.12, 0.06])
+    radius_text_box = TextBox(ax=radius_ax, label='Radius (px)  ',
+                              initial=str(radius_out),
+                              textalignment='center')
+
+    update_ax = fig.add_axes([0.55, 0.06, 0.15, 0.06])
+    update_button = Button(update_ax, 'Update')
+
+    # Update the figure anytime the 'update' button is clicked
+    def rolling_ball_update(event):
+        # Use the new Python keyword 'nonlocal' to gain access and
+        # update these variables from within this scope.
+        nonlocal radius_out
+        nonlocal img_out
+
+        # Show busy indicator before computation
+        status_text.set_text('Computing...')
+        status_text.set_color('red')
+        update_button.label.set_text('Computing...')
+        fig.canvas.draw_idle()
+        fig.canvas.flush_events()
+
+        # The GUI widgets are defined in a higher-level scope, so
+        # they can be accessed directly within this interior function
+        radius_out = int(radius_text_box.text)
+        if radius_out < 1:
+            radius_out = 1
+
+        img_inv = util.invert(img_0)
+        bg = rest.rolling_ball(img_inv, radius=radius_out, nansafe=False)
+        bg = img_as_ubyte(bg)
+        img_out = util.invert(img_inv - bg)
+        img_out = img_as_ubyte(img_out)
+
+        # Update the images
+        img_corr_obj.set(data=img_out)
+        img_bg_obj.set(data=bg)
+        ax_corr.set_title(f"Background-corrected (r={radius_out})")
+
+        # Restore ready indicator
+        status_text.set_text('Ready')
+        status_text.set_color('green')
+        update_button.label.set_text('Update')
+        fig.canvas.draw()
+
+    # Call the update function when the 'update' button is clicked
+    update_button.on_clicked(rolling_ball_update)
+
+    plt.show()
+
+    # Save final filter parameters
+    fltr_params = ["rolling_ball", radius_out]
+
+    return [img_out, fltr_params]
+    
 
 def interact_global_thresholding(img_in):
     """

--- a/src/imppy3d/ski_interactive_processing.py
+++ b/src/imppy3d/ski_interactive_processing.py
@@ -643,6 +643,109 @@ def interact_rolling_ball(img_in, radius_init=35):
     return [img_out, fltr_params]
     
 
+def interact_segmentation_type():
+    """
+    Display a window with three buttons to choose a segmentation type:
+    Global, Adaptive, or Hysteresis. The selected button stays
+    highlighted in green so the user can confirm their choice before
+    closing the window.
+
+    This function is intended to be called before
+    interact_driver_thresholding() so the user can choose which
+    thresholding algorithm to use interactively, rather than
+    commenting/uncommenting code blocks.
+
+     ---- INPUT ARGUMENTS ----
+    None.
+
+     ---- RETURNED ----
+    [seg_type]: A string, one of "global_threshold",
+        "adaptive_threshold", or "hysteresis_threshold_text". These
+        strings match the thresh_type argument expected by
+        interact_driver_thresholding() in ski_driver_functions.py.
+
+     ---- SIDE EFFECTS ----
+    Function input arguments are not altered. Nothing is written to the
+    hard drive. This function is a read-only function. It does pop-up
+    a new window for the user to make a selection. Strings are printed
+    to standard output.
+    """
+
+    # Default selection
+    seg_type = "global_threshold"
+
+    fig, ax = plt.subplots(1, 1)
+    fig.set_size_inches(6, 3)
+    ax.set_visible(False)
+    fig.suptitle("Choose segmentation type, then close this window",
+                 fontsize=12)
+
+    plt.subplots_adjust(bottom=0.35, top=0.80)
+
+    global_ax = fig.add_axes([0.08, 0.10, 0.24, 0.15])
+    global_button = Button(global_ax, 'Global')
+
+    adaptive_ax = fig.add_axes([0.38, 0.10, 0.24, 0.15])
+    adaptive_button = Button(adaptive_ax, 'Adaptive')
+
+    hysteresis_ax = fig.add_axes([0.68, 0.10, 0.24, 0.15])
+    hysteresis_button = Button(hysteresis_ax, 'Hysteresis')
+
+    # Status text showing current selection
+    status_text = fig.text(0.5, 0.35, 'Selected: Global',
+                           ha='center', fontsize=12,
+                           fontweight='bold')
+
+    # Store default button color for resetting unselected buttons
+    default_color = global_button.color
+
+    def _set_button_color(button, color):
+        """Set a Button's persistent color (survives redraws)."""
+        button.color = color
+        button.hovercolor = color
+        button.ax.set_facecolor(color)
+
+    # Highlight the default selection
+    _set_button_color(global_button, 'lightgreen')
+
+    def select_global(event):
+        nonlocal seg_type
+        seg_type = "global_threshold"
+        status_text.set_text('Selected: Global')
+        _set_button_color(global_button, 'lightgreen')
+        _set_button_color(adaptive_button, default_color)
+        _set_button_color(hysteresis_button, default_color)
+        fig.canvas.draw()
+
+    def select_adaptive(event):
+        nonlocal seg_type
+        seg_type = "adaptive_threshold"
+        status_text.set_text('Selected: Adaptive')
+        _set_button_color(global_button, default_color)
+        _set_button_color(adaptive_button, 'lightgreen')
+        _set_button_color(hysteresis_button, default_color)
+        fig.canvas.draw()
+
+    def select_hysteresis(event):
+        nonlocal seg_type
+        seg_type = "hysteresis_threshold_text"
+        status_text.set_text('Selected: Hysteresis')
+        _set_button_color(global_button, default_color)
+        _set_button_color(adaptive_button, default_color)
+        _set_button_color(hysteresis_button, 'lightgreen')
+        fig.canvas.draw()
+
+    global_button.on_clicked(select_global)
+    adaptive_button.on_clicked(select_adaptive)
+    hysteresis_button.on_clicked(select_hysteresis)
+
+    plt.show()
+
+    print(f"\n  Segmentation type selected: {seg_type}")
+
+    return seg_type
+    
+
 def interact_global_thresholding(img_in):
     """
     Applies a simple threshold to a grayscale image resulting in a


### PR DESCRIPTION
## Add 2D rolling ball background subtraction, busy indicators, and segmentation type selector

### Summary
- Add rolling ball background subtraction as a new interactive filter and batch-apply driver function pair for 2D images. The interactive-mode has a 3-panel display (original, corrected, estimated background). For 3D stacks, tune on a single representative slice then apply slice-by-slice in a loop.
- Add "Computing..." / "Ready" busy indicators to a few interactive functions whose update callbacks take noticeable time (`interact_nl_means_denoise`, `interact_hysteresis_threshold`, `interact_hysteresis_threshold2`, `interact_rolling_ball`). This pattern could be expanded across more of the codes.
- Add `interact_segmentation_type()`, a 3-button selector window (Global / Adaptive / Hysteresis) that returns the `thresh_type` string expected by `interact_driver_thresholding()`, replacing the comment/uncomment workflow in the example script `interactive_scikit_processing_single_image.py`.
- Some parts written with the assistance of Claude Opus 4.6, with complete review by me.

### Motivation

I was using the grain_size_analysis_tool, which builds on IMPPy3D, for metallographic image analysis. As part of that effort the following three things came up:

1. **Background subtraction was needed.** Uneven illumination or etching gradients can result in un-even background brightness, which make segmentation hard. The rolling ball algorithm (`skimage.restoration.rolling_ball`) handles this well, but imppy3d had not implemented it (or other background subtraction) routines before.

2. **No feedback during slow filters in interactive mode.** Several interactive functions (for my application, non-local means denoising and rolling ball) can take seconds to update. With no visual feedback, it was hard to tell if I was looking at the old or new image, especially if I wasn't paying close attention to the update. Adding a status indicator helps with this.

3. **Switching segmentation type required editing code.** I wanted to be able to easily change segmentation type to see which was best during the workflow. The examples only achieve this by commenting/uncommenting lines, which is less than ideal. Adding an interactive selector lets users switch methods at runtime without touching the source.

### Changes by target file

| Target file                                      | What's added                                                                                                              |
|--------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
| `ski_interactive_processing.py`                  | `interact_rolling_ball()` -- 2D interactive rolling ball tuning                                                           |
| `ski_interactive_processing.py`                  | `interact_segmentation_type()`                                                                                            |
| `ski_interactive_processing.py`                  | Busy indicator patches for `interact_nl_means_denoise`, `interact_hysteresis_threshold`, `interact_hysteresis_threshold2` |
| `ski_driver_functions.py`                        | `interact_driver_rolling_ball()`, `apply_driver_rolling_ball()` -- 2D driver functions                                    |
| `interactive_scikit_processing_single_image.py`  | Replace 3 thresholding blocks with selector + dispatch                                                                    |

### New imports required

| File                                            | Imports added                                       |
|-------------------------------------------------|-----------------------------------------------------|
| `ski_interactive_processing.py`                 | `from skimage import util`                          |
| `ski_driver_functions.py`                       | `from skimage import util`                          |
| `interactive_scikit_processing_single_image.py` | `import imppy3d.ski_interactive_processing as sint` |

All other imports (`Button`, `TextBox`, `Slider`, `plt`, `np`, `rest`, `img_as_ubyte`, etc.) are already present.

### New functions

**`interact_rolling_ball(img_in, radius_init=35)`** -- Interactive 3-panel rolling ball tuning for a single 2D image. Assumes features of interest are darker than the background (internally inverts before applying). For 3D stacks, tune on one slice then loop with `apply_driver_rolling_ball()`.

**`apply_driver_rolling_ball(img_in, fltr_params_in, quiet_in=False)`** -- Non-interactive batch driver for 2D slices. Accepts `["rolling_ball", radius]` parameter list. Designed for slice-by-slice loops over 3D stacks.

**`interact_driver_rolling_ball(img_in, radius_init=35)`** -- Interactive driver wrapper (calls `interact_rolling_ball` then prints parameters). Single 2D slice only.

**`interact_segmentation_type()`** -- 3-button selector window returning `"global_threshold"`, `"adaptive_threshold"`, or `"hysteresis_threshold_text"`, with the string result passed directly to `interact_driver_thresholding()`.

### Busy indicator pattern

Added a `status_text` element at the bottom of the figure and wraps the computation in:
```python
# Before computation
status_text.set_text('Computing...')
status_text.set_color('red')
update_button.label.set_text('Computing...')  # where a Button exists
fig.canvas.draw_idle()
fig.canvas.flush_events()

# ... computation ...

# After computation
status_text.set_text('Ready')
status_text.set_color('green')
update_button.label.set_text('Update')
fig.canvas.draw()
```
For the Slider-based `interact_hysteresis_threshold`, only `status_text` is used (no button label to change).

### Testing
- [x] Ran `interactive_scikit_processing_single_image.py` end-to-end with each segmentation type (global, adaptive, hysteresis) via the new selector
- [x] Verified busy indicator appears during denoise, hysteresis (both slider and textbox variants), and rolling ball updates
- [x] Verified rolling ball 3-panel display updates correctly and returns expected `fltr_params`
- [x] Verified `apply_driver_rolling_ball()` in a slice loop on a small 3D test stack
