### PR TITLE
Fix image-sequence ordering: natural filename sort + flipz name/frame alignment

### DIFF
--- a/src/imppy3d/import_export.py
+++ b/src/imppy3d/import_export.py
@@ -4,6 +4,26 @@ from skimage.util import img_as_ubyte, img_as_uint
 from skimage import io
 import glob
 import os.path
+import re
+
+
+def _natural_sort_key(name):
+    """Sort key that orders any embedded integers numerically, not lexically.
+
+    A plain string sort places "img_10.tif" before "img_2.tif" (because the
+    character '1' < '2'), which silently reorders an image stack so that, for
+    example, the second-loaded frame is actually source image 10. Splitting the
+    name into digit and non-digit runs and comparing the digit runs as integers
+    restores numeric order: "img_2" < "img_10". Zero-padded names ("img_0002"
+    vs. "img_0010") are unaffected -- they already sort correctly either way.
+
+    ``re.split(r'(\\d+)', ...)`` always yields an alternating text/digits/text/
+    ... list, so for a set of similarly-structured filenames the digit runs land
+    at the same positions and the mixed int/str key elements never compare
+    against each other.
+    """
+    return [int(chunk) if chunk.isdigit() else chunk
+            for chunk in re.split(r'(\d+)', name)]
 
 
 def load_image(path_in, img_bitdepth='uint8', quiet_in=False):
@@ -507,7 +527,9 @@ def load_image_seq(path_in, file_name_in='', img_bitdepth_in='uint8',
 
     # The Glob module does not guarantee that the results will be sorted.
     img_names = list(dict.fromkeys(img_names)) # Removes duplicates
-    img_names.sort() # Asecending order based on the string file names
+    # Natural (numeric-aware) sort so "img_10" follows "img_9" instead of
+    # "img_1"; a plain string sort would silently reorder un-zero-padded stacks.
+    img_names.sort(key=_natural_sort_key)
 
     if indices_keep: # If not empty
         # If not already, force the data to be positive and of type integer
@@ -748,7 +770,9 @@ def load_image_seq_ASCII(path_in, file_name_in='', indices_in=(),
 
     # The Glob module does not guarantee that the results will be sorted.
     img_names = list(dict.fromkeys(img_names)) # Removes duplicates
-    img_names.sort() # Asecending order based on the string file names
+    # Natural (numeric-aware) sort so "img_10" follows "img_9" instead of
+    # "img_1"; a plain string sort would silently reorder un-zero-padded stacks.
+    img_names.sort(key=_natural_sort_key)
 
     if indices_keep: # If not empty
         # If not already, force the data to be positive and of type integer

--- a/src/imppy3d/import_export.py
+++ b/src/imppy3d/import_export.py
@@ -644,6 +644,9 @@ def load_image_seq(path_in, file_name_in='', img_bitdepth_in='uint8',
         print(f"\nReversing the order of the image stack (i.e.," \
             + " flipping the Z-direction)...")
         imgs = np.flip(imgs, axis=0)
+        # Reverse the filename list too so it stays aligned with the frames;
+        # otherwise the returned img_names no longer correspond to imgs.
+        img_names.reverse()
 
     # Return the image objects, image properties, and string file names
     return [imgs, img_names]

--- a/tests/main_run_tests.py
+++ b/tests/main_run_tests.py
@@ -29,6 +29,7 @@ os.makedirs(temp_dir_path, exist_ok=True)
 flag_000, msg_000 = t_io.io_img_stack_8bit(temp_dir_path)
 flag_001, msg_001 = t_io.io_img_stack_16bit(temp_dir_path)
 flag_002, msg_002 = t_io.io_multipage_tiff_stack(temp_dir_path)
+flag_003, msg_003 = t_io.natural_sort_img_seq(temp_dir_path)
 
 
 # ---------------- CREATION OF VTK MODELS ---------------- 
@@ -60,6 +61,7 @@ print(f"\n\n\n---------- SUMMARY OF ALL UNIT TESTS ----------")
 print(msg_000)
 print(msg_001)
 print(msg_002)
+print(msg_003)
 
 print(msg_100)
 print(msg_101)

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -227,6 +227,34 @@ def natural_sort_img_seq(dir_path='./'):
         del_all_img_files(dir_path)
         return [1, test_name + " ERROR"]
 
+    # With flipz=True the stack is reversed, and the returned filenames must stay
+    # aligned with the frames: names[k] must name the file whose frame is imgs[k].
+    try:
+        imgs_f, names_f = imex.load_image_seq(dir_path,
+            file_name_in="natsort_", img_bitdepth_in='uint8', flipz=True)
+    except:
+        print(f"\nERROR: Failed to load the natural-sort test stack with flipz.")
+        del_all_img_files(dir_path)
+        return [1, test_name + " ERROR"]
+
+    flip_order = [int(imgs_f[k, 0, 0]) for k in range(n_imgs)]
+    if flip_order != list(range(n_imgs, 0, -1)):
+        print(f"\nERROR: flipz stack not reversed. Expected "
+              f"{list(range(n_imgs, 0, -1))}, got {flip_order}.")
+        del_all_img_files(dir_path)
+        return [1, test_name + " ERROR"]
+
+    # names_f[k] should reference the same index encoded in imgs_f[k, 0, 0].
+    for k in range(n_imgs):
+        name_idx = int(''.join(ch for ch in os.path.basename(names_f[k])
+                               if ch.isdigit()))
+        if name_idx != int(imgs_f[k, 0, 0]):
+            print(f"\nERROR: flipz misaligned names and frames at index {k}: "
+                  f"name '{names_f[k]}' (idx {name_idx}) vs frame idx "
+                  f"{int(imgs_f[k, 0, 0])}.")
+            del_all_img_files(dir_path)
+            return [1, test_name + " ERROR"]
+
     del_all_img_files(dir_path)
     return [0, test_name + " SUCCESS"] # (False) No errors
 

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -184,15 +184,64 @@ def io_multipage_tiff_stack(dir_path='./'):
     return [0, test_name + " SUCCESS"] # (False) No errors
 
 
+def natural_sort_img_seq(dir_path='./'):
+    test_name = "\nTEST: NATURAL (NUMERIC) ORDERING OF IMAGE SEQUENCES..."
+    print(test_name)
+
+    os.makedirs(dir_path, exist_ok=True)
+
+    # Write image files with UN-zero-padded numeric names (natsort_1.tif ..
+    # natsort_12.tif). save_image_seq() zero-pads its output, so it cannot
+    # reproduce this case -- we write the names directly. Each frame encodes its
+    # own 1-based index in pixel [0, 0] so the load order can be verified.
+    # A plain string sort would order these as 1, 10, 11, 12, 2, 3, ... .
+    n_imgs = 12
+    for ii in range(1, n_imgs + 1):
+        img_ii = np.zeros((16, 16), dtype=np.uint8)
+        img_ii[0, 0] = ii
+        img_path = os.path.normcase(dir_path + f"natsort_{ii}.tif")
+        try:
+            imex.save_image(img_ii, img_path, quiet_in=True)
+        except:
+            print(f"\nERROR: Failed to save natural-sort test image {ii}.")
+            return [1, test_name + " ERROR"]
+
+    try:
+        imgs_in, imgs_names = imex.load_image_seq(dir_path,
+            file_name_in="natsort_", img_bitdepth_in='uint8')
+    except:
+        print(f"\nERROR: Failed to load the natural-sort test image stack.")
+        return [1, test_name + " ERROR"]
+
+    if imgs_in is None or imgs_in.shape[0] != n_imgs:
+        print(f"\nERROR: Expected {n_imgs} images, got "
+              f"{None if imgs_in is None else imgs_in.shape[0]}.")
+        del_all_img_files(dir_path)
+        return [1, test_name + " ERROR"]
+
+    # Frame k (0-based) must be source image k+1 -> pixel [0, 0] == k + 1.
+    loaded_order = [int(imgs_in[k, 0, 0]) for k in range(n_imgs)]
+    if loaded_order != list(range(1, n_imgs + 1)):
+        print(f"\nERROR: Image stack loaded out of order. Expected "
+              f"{list(range(1, n_imgs + 1))}, got {loaded_order}.")
+        del_all_img_files(dir_path)
+        return [1, test_name + " ERROR"]
+
+    del_all_img_files(dir_path)
+    return [0, test_name + " SUCCESS"] # (False) No errors
+
+
 if __name__ == '__main__':
 
     temp_dir_path = "./local_swap/"
     flag_000, msg_000 = io_img_stack_8bit(temp_dir_path)
     flag_001, msg_001 = io_img_stack_16bit(temp_dir_path)
     flag_002, msg_002 = io_multipage_tiff_stack(temp_dir_path)
+    flag_003, msg_003 = natural_sort_img_seq(temp_dir_path)
 
     print(f"\n\n\n---------- SUMMARY ----------")
     print(msg_000)
     print(msg_001)
     print(msg_002)
+    print(msg_003)
     print("\n")


### PR DESCRIPTION
Two related correctness bugs in how `load_image_seq` / `load_image_seq_ASCII` order the frames (and names) they return.

## 1. Lexicographic filename sort

The matched filenames are ordered with a plain string sort (`img_names.sort()`). For stacks whose names end in an **un-zero-padded** integer (`img_1.tif` … `img_10.tif`), that gives:

```
img_1, img_10, img_2, img_3, ..., img_9
```

so `img_10` lands in the second slot and the returned stack is silently misaligned. Index 1 is actually source image 10, and so on. This impacts image stacks made by hand or by a microscope software that uses "natural" image numbering (non-zero-padded). Anything relying on slice order (re-slicing, per-index export, raw↔processed correspondence) is then wrong, with no error. Zero-padded stacks are unaffected.

**Fix:** a dependency-free `_natural_sort_key` helper that compares embedded integer runs numerically (`img_2` < `img_10`), used as `key=` for both loaders' sorts. Because the sort now runs *before* the `indices_in` sub-selection, sliced loads also select the correct frames.

## 2. `flipz` misaligns names and frames

`load_image_seq` applies `flipz` by reversing the array (`imgs = np.flip(imgs, axis=0)`) but returns `img_names` **unchanged**, so with `flipz=True` the returned filenames no longer correspond to their frames.

**Fix:** reverse `img_names` alongside the frames. Use in-place .reverse() to keep style consistent and avoid extra memory use.

## Tests

Extended `tests/test_import_export.py` (`natural_sort_img_seq`, wired into `main_run_tests.py`): writes 12 un-padded frames each encoding its index in pixel `[0,0]`, asserts they load 1→12, and asserts that under `flipz=True` the stack reverses **and** each returned name still matches its frame. Both assertions fail on the current code and pass with the fix.

Coded with help from Claude Code Opus 4.8.